### PR TITLE
富山市のネットワークを作成する

### DIFF
--- a/Dockerfile_filter_network
+++ b/Dockerfile_filter_network
@@ -1,0 +1,9 @@
+FROM debian:bullseye
+
+RUN apt-get update && apt-get install -y \
+    osmium-tool \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /data
+
+ENTRYPOINT ["osmium"]

--- a/script/download_data.sh
+++ b/script/download_data.sh
@@ -5,29 +5,53 @@ DSTDIR=network/input
 mkdir -p $DSTDIR
 rm $DSTDIR/*
 
-# OSM
+### OSM ###
+
+# 北陸全体のデータをダウンロード
 curl -L https://download.geofabrik.de/asia/japan/chubu-latest.osm.pbf -o $DSTDIR/chubu-latest.osm.pbf
 
-# GTFS
+# 北陸全体から富山市周辺のみを抽出
+docker build -t custom-osmium -f Dockerfile_filter_network .
+docker run --rm \
+  -v "$(pwd):/data" \
+  custom-osmium \
+  extract \
+  --bbox=137.10170402536042,36.56588602838791,137.3220496915057,36.73683460188385 \
+  -o $DSTDIR/chubu-latest-filtered.osm.pbf \
+  $DSTDIR/chubu-latest.osm.pbf
+rm $DSTDIR/chubu-latest.osm.pbf
+
+### GTFS ###
+
 # 富山地方鉄道バス
 curl -L https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip?rid=current -o $DSTDIR/chitetsubus-gtfs.zip
+
 # 富山地方鉄道市内電車
 curl -L https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip?rid=current -o $DSTDIR/chitetsushinaidensha-gtfs.zip
+
 # 婦中コミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip?rid=current -o $DSTDIR/fuchucommunitybus-gtfs.zip
+
 # 大山コミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=current -o $DSTDIR/oyamacommunitybus-gtfs.zip
+
 # 水橋ふれあいコミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip?rid=current -o $DSTDIR/mizuhashifureaicommunitybus-gtfs.zip
+
 # 堀川南地域コミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=current -o $DSTDIR/horikawaminamicommunitybus-gtfs.zip
+
 # 八尾コミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip?rid=current -o $DSTDIR/yatsuocommunitybus-gtfs.zip
+
 # 呉羽いきいきバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=current -o $DSTDIR/kurehaikiikibus-gtfs.zip
+
 # 山田コミュニティバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip?rid=current -o $DSTDIR/yamadacommunitybus-gtfs.zip
+
 # 上条コミバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/jojocommunitybus/files/feed.zip?rid=current -o $DSTDIR/jojocommunitybus-gtfs.zip
+
 # まいどはやバス
 curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip?rid=current -o $DSTDIR/maidohayabus-gtfs.zip

--- a/script/download_data.sh
+++ b/script/download_data.sh
@@ -3,10 +3,31 @@
 DSTDIR=network/input
 
 mkdir -p $DSTDIR
+rm $DSTDIR/*
 
 # OSM
-curl -L  https://download.geofabrik.de/asia/japan/shikoku-latest.osm.pbf -o $DSTDIR/shikoku-latest.osm.pbf
+curl -L https://download.geofabrik.de/asia/japan/chubu-latest.osm.pbf -o $DSTDIR/chubu-latest.osm.pbf
 
 # GTFS
-# 鳴門市地域バス
-curl -L https://api.gtfs-data.jp/v2/organizations/narutocity/feeds/narutocitychiikibus/files/feed.zip?rid=current -o $DSTDIR/tokushima-local-bus-gtfs.zip
+# 富山地方鉄道バス
+curl -L https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsubus/files/feed.zip?rid=current -o $DSTDIR/chitetsubus-gtfs.zip
+# 富山地方鉄道市内電車
+curl -L https://api.gtfs-data.jp/v2/organizations/chitetsu/feeds/chitetsushinaidensha/files/feed.zip?rid=current -o $DSTDIR/chitetsushinaidensha-gtfs.zip
+# 婦中コミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/fuchucommunitybus/files/feed.zip?rid=current -o $DSTDIR/fuchucommunitybus-gtfs.zip
+# 大山コミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/oyamacommunitybus/files/feed.zip?rid=current -o $DSTDIR/oyamacommunitybus-gtfs.zip
+# 水橋ふれあいコミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/mizuhashifureaicommunitybus/files/feed.zip?rid=current -o $DSTDIR/mizuhashifureaicommunitybus-gtfs.zip
+# 堀川南地域コミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/horikawaminamicommunitybus/files/feed.zip?rid=current -o $DSTDIR/horikawaminamicommunitybus-gtfs.zip
+# 八尾コミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yatsuocommunitybus/files/feed.zip?rid=current -o $DSTDIR/yatsuocommunitybus-gtfs.zip
+# 呉羽いきいきバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/kurehaikiikibus/files/feed.zip?rid=current -o $DSTDIR/kurehaikiikibus-gtfs.zip
+# 山田コミュニティバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/yamadacommunitybus/files/feed.zip?rid=current -o $DSTDIR/yamadacommunitybus-gtfs.zip
+# 上条コミバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/jojocommunitybus/files/feed.zip?rid=current -o $DSTDIR/jojocommunitybus-gtfs.zip
+# まいどはやバス
+curl -L https://api.gtfs-data.jp/v2/organizations/toyamacity/feeds/maidohayabus/files/feed.zip?rid=current -o $DSTDIR/maidohayabus-gtfs.zip

--- a/test/test_car.py
+++ b/test/test_car.py
@@ -9,16 +9,12 @@ headers = {"Content-Type": "application/json"}
 def test_route_car():
     payload = {
         "stops": [
-            {
-                "coord": {"lat": 34.15646, "lon": 134.6144},
-                "name": "stop1",
-            },
-            {"coord": {"lat": 34.16906, "lon": 134.6155}, "name": "stop2"},
-            {
-                "coord": {"lat": 34.16423, "lon": 134.6277},
-                "name": "stop3",
-            },
+            {"coord": {"lat": 36.61095, "lon": 137.2509}, "name": "stop1"},
+            {"coord": {"lat": 36.61065, "lon": 137.2145}, "name": "stop2"},
+            {"coord": {"lat": 36.61303, "lon": 137.1858}, "name": "stop3"},
+            {"coord": {"lat": 36.63100, "lon": 137.2149}, "name": "stop4"},
         ],
+        "debug": False,
     }
 
     # 全体
@@ -27,38 +23,50 @@ def test_route_car():
     response_data = response.json()
     assert response_data["status"] == "OK"
     result = response_data["result"]
-    assert result["distance"] == 4903.0
-    assert result["duration"] == 547.0
+    assert result["distance"] == 15247.87
+    assert result["duration"] == 1091.0
 
     # subroute 0
     subroute_0 = result["subroutes"][0]
-    assert subroute_0["duration"] == 187.0
-    assert subroute_0["distance"] == 1721.72
+    assert subroute_0["duration"] == 212.0
+    assert subroute_0["distance"] == 3433.62
     assert (
         subroute_0["polyline"]
-        == "abnoE}~rtXa@c@s@k@gA}@iAtAyBjDm@z@wBfDeCnDIB[Mu@a@UKgGiB_@G_EQa@G_AvDg@UKE}BaAuD_BwGyCCAYMIEcAa@o@Sy@Qw@IkECO?m@Aw@AY?"
+        == "msm~EkxudY@BnA~LHz@`@zDRvARnA^zB?r@CdCKxEEpBAd@Ej@In@ABOl@Qd@]p@q@vA[bAYjBq@rESv@]v@Yn@Uj@SxAGdBExAShFUhEIjBMnBYjCi@xD_@vCCZF`@JTLPhAdALL`@ZrAfAh@j@^b@\\b@DFbB~BLNJFEtA_@hPObH?TAdAMxFItGB|AHdB`@hNN`GAhE?j@EhA"
     )
     assert subroute_0["org"]["name"] == "stop1"
     assert subroute_0["dst"]["name"] == "stop2"
 
     # subroute 1
     subroute_1 = result["subroutes"][1]
-    assert subroute_1["duration"] == 186.0
-    assert subroute_1["distance"] == 1494.84
+    assert subroute_1["duration"] == 201.0
+    assert subroute_1["distance"] == 2584.59
     assert (
         subroute_1["polyline"]
-        == "uspoEi}rtX}CCDmJBoAF{@Fm@He@Ja@Ja@\\}@`@y@nBgDZk@pAwBfB{ClAsBZg@xDwGn@eAjCyEm@c@a@[c@[DKrBaDnAuBp@aAJKUU"
+        == "upm~EwundYEnAKrCOjCCdDAvHEbGEpG[rFa@rIYfEaArNcApLU`B}@zKk@vGMzC?N@bDPdFArAMzAC^Eb@I`AWrE?HQtDElAKtFMvF"
     )
     assert subroute_1["org"]["name"] == "stop2"
     assert subroute_1["dst"]["name"] == "stop3"
 
     # subroute 2
     subroute_2 = result["subroutes"][2]
-    assert subroute_2["duration"] == 174.0
-    assert subroute_2["distance"] == 1686.44
+    assert subroute_2["duration"] == 361.0
+    assert subroute_2["distance"] == 4591.89
     assert (
         subroute_2["polyline"]
-        == "swooEwjutXTTKJq@`AoAtBsB`DEJb@Z`@Zl@b@XTVRjBhCxAhBnA~A|AlBh@p@PTP\\b@hABFl@rAr@hAzArBlAxAxA|Ah@`@vApAzBfBr@n@xAfAbCjBVPzCzBjAjAfA|@r@j@`@b@"
+        == "o`n~EkbidYLwFJuFDmAPuD?IVsEHaADc@B_@L{AeBJkC@eC?wFAk@C[E]IYI[MYMwEqCOI[M_@GUEYA]A_A@qBBcFFU@{B?m@Ay@EaCQQA[Cc@Ei@EiCSa@CyJ{@y@GQCwDYy@GaCQaEk@mAQEAoF}@s@M{@EcAAoBLUD?]?oC?aC?sB@qDBeAHqAb@yFHcADe@Dc@b@eGL}APwBJuAFuB?}AEaECmCKaKGgFAY?]A[AsAE}EBwCDwAJqBLiALyAT{BLkAVqB"
     )
     assert subroute_2["org"]["name"] == "stop3"
+    assert subroute_2["dst"]["name"] == "stop4"
+    
+    # subroute 3
+    # subroute 2
+    subroute_2 = result["subroutes"][3]
+    assert subroute_2["duration"] == 317.0
+    assert subroute_2["distance"] == 4637.77
+    assert (
+        subroute_2["polyline"]
+        == "ipq~EsxndYHq@^cDJcAV}BF{@@aACgAKeBE}@I_BMsB|@OpAKXAV?dAIbCQ^EjD]p@K`AOvAYpDq@v@OrAYxFiAhE{@hEcAD?hCw@\\IpA[|Ac@zBe@l@[n@o@vAmA|ByBp@g@rGcG`@_@f@e@f@iA~@oBJUnCqFPg@Nc@TqAx@qENa@Zy@`@i@d@o@HA`@I|@CVAJAB[^wCh@yDXkCLoBHkBTiERiFDyAFeBRyATk@Xo@\\w@Rw@p@sEXkBZcAp@wA\\q@Pe@Nm@@CHo@Dk@@e@DqBJyEBeC?s@_@{BSoASwAa@{DI{@oA_MAC"
+    )
+    assert subroute_2["org"]["name"] == "stop4"
     assert subroute_2["dst"]["name"] == "stop1"

--- a/test/test_ptrans.py
+++ b/test/test_ptrans.py
@@ -11,7 +11,7 @@ def test_route_ptrans():
         "dst_coord": {"lat": 34.18884, "lon": 134.5953},
         "start_time": "2024-12-07T15:10:00",
     }
-    
+
     response = requests.post(url, headers=headers, data=json.dumps(payload))
     assert response.status_code == 400
     # assert response.status_code == 200

--- a/test/test_route_cache.py
+++ b/test/test_route_cache.py
@@ -6,16 +6,12 @@ route_cache_url = "http://localhost:3000/route/cache"
 headers = {"Content-Type": "application/json"}
 payload = {
     "stops": [
-        {
-            "coord": {"lat": 34.15646, "lon": 134.6144},
-            "name": "stop1",
-        },
-        {"coord": {"lat": 34.16906, "lon": 134.6155}, "name": "stop2"},
-        {
-            "coord": {"lat": 34.16423, "lon": 134.6277},
-            "name": "stop3",
-        },
+        {"coord": {"lat": 36.61095, "lon": 137.2509}, "name": "stop1"},
+        {"coord": {"lat": 36.61065, "lon": 137.2145}, "name": "stop2"},
+        {"coord": {"lat": 36.61303, "lon": 137.1858}, "name": "stop3"},
+        {"coord": {"lat": 36.63100, "lon": 137.2149}, "name": "stop4"},
     ],
+    "debug": False,
 }
 
 


### PR DESCRIPTION
※コードレビュは不要。変更内容の共有を目的としてプルリクを出しているので、雰囲気だけ見てもらえれば

これまでは四国のネットワークデータを作成していたが、富山市のデータを作成するように変更した。
車ネットワークは、北陸全体のosmデータをダウンロードしたのち、下記のエリアのみ切り取ってコンバートしている。
<img width="397" alt="富山市のネットワーク" src="https://github.com/user-attachments/assets/04f41b48-f318-46c4-9d47-eb8371182c60">

公共交通は、GTFSデータリポジトリのうち富山市っぽい名前のデータをダウンロードして用いている。
作成したデータを用いて経路探索（徒歩＋公共交通）をしている様子は下記。
![富山市](https://github.com/user-attachments/assets/8df78a5c-f9b3-4858-99a7-6f8c509a7d59)

